### PR TITLE
feat: send nan after timeout

### DIFF
--- a/metricq_source_bacnet/source.py
+++ b/metricq_source_bacnet/source.py
@@ -431,8 +431,8 @@ class BacnetSource(Source):
                 for metric_id in metrics:
                     now = Timestamp.now()
                     last_timestamp = self._last_value_send_by_metric.get(metric_id, now)
-                    if now - last_timestamp >= Timedelta.from_s(interval * 6):
-                        timestamp_nan = now - Timedelta.from_s(interval)
+                    if now - last_timestamp >= 6 * Timedelta.from_s(interval):
+                        timestamp_nan = last_timestamp + 5 * Timedelta.from_s(interval)
                         self._last_value_send_by_metric[metric_id] = timestamp_nan
                         await self.send(metric_id, timestamp_nan, float("nan"))
 

--- a/metricq_source_bacnet/source.py
+++ b/metricq_source_bacnet/source.py
@@ -61,6 +61,7 @@ class BacnetSource(Source):
         self._worker_tasks: List[Task] = []
         self.disk_cache_filename = disk_cache_filename
         self._old_bacnet_reader_config = {}
+        self._last_value_send_by_metric: Dict[str, Timestamp] = {}
 
         register_extended_object_types()
 
@@ -123,6 +124,7 @@ class BacnetSource(Source):
                 "description": device_config.get("description", "$objectDescription"),
                 "chunk_size": device_config.get("chunkSize"),
                 "device_identifier": device_config.get("deviceIdentifier"),
+                "nan_at_timeout": device_config.get("nanAtTimeout"),
             }
 
             self._device_config[device_address_str] = object_group_device_config
@@ -139,6 +141,11 @@ class BacnetSource(Source):
 
                 if "description" in object_config:
                     object_group_config["description"] = object_config["description"]
+
+                if "nanAtTimeout" in object_config:
+                    object_group_config["nan_at_timeout"] = object_config[
+                        "nanAtTimeout"
+                    ]
 
                 self._object_groups.append(object_group_config)
 
@@ -224,6 +231,7 @@ class BacnetSource(Source):
                     if "presentValue" in object_result and isinstance(
                         object_result["presentValue"], (int, float)
                     ):
+                        self._last_value_send_by_metric[metric_id] = timestamp
                         await self.send(
                             metric_id, timestamp, object_result["presentValue"]
                         )
@@ -418,6 +426,21 @@ class BacnetSource(Source):
                 device_address_str, objects, chunk_size=chunk_size
             )
 
+            if object_group.get("nan_at_timeout"):
+
+                for metric_id in metrics:
+                    now = Timestamp.now()
+                    last_timestamp = self._last_value_send_by_metric.get(metric_id, now)
+                    if now - last_timestamp >= Timedelta.from_s(interval * 6):
+                        timestamp_nan = now - Timedelta.from_s(interval)
+                        self._last_value_send_by_metric[metric_id] = timestamp_nan
+                        await self.send(metric_id, timestamp_nan, float("nan"))
+
+                        logger.warn(
+                            "Timeout for metric {} reached. Sending NaN! Device: {}",
+                            metric_id,
+                            device_address_str,
+                        )
             try:
                 deadline += Timedelta.from_s(interval)
                 now = Timestamp.now()


### PR DESCRIPTION
If activated, send a NaN value when last value was send more than 6 time the request interval ago. Timestamp of the NaN value is `last + 5 * interval`